### PR TITLE
bugfix: DKL-DI-0005 false positive

### DIFF
--- a/pkg/assessor/manifest/manifest.go
+++ b/pkg/assessor/manifest/manifest.go
@@ -354,7 +354,7 @@ func reducableAptGetInstall(cmdSlices map[int][]string) bool {
 			useAptLibrary = true
 		}
 		// remove cache must be run after apt library directory changed
-		if useAptLibrary && containsThreshold(cmdSlice, removeAptLibCmds, 3) {
+		if useAptLibrary && (containsThreshold(cmdSlice, removeAptLibCmds, 3) || checkAptCommand(cmdSlice, "dist-clean") || checkAptCommand(cmdSlice, "distclean")) {
 			return false
 		}
 	}


### PR DESCRIPTION
When using `apt`, look for `distclean/dist-clean` as well, see https://github.com/goodwithtech/dockle/issues/282.

**NOTE:** this PR is a port of https://github.com/goodwithtech/dockle/pull/283 to this fork, since upstream seems not maintained anymore.